### PR TITLE
Fix few typos and change "cargo compiler" to "rust compiler"

### DIFF
--- a/_posts/2022-11-01-rust-fiddling-2-years.md
+++ b/_posts/2022-11-01-rust-fiddling-2-years.md
@@ -47,11 +47,11 @@ data structures, but also had the side effect of pushing back the moment when I 
 Fortunately enough, the compiler comes to the rescue with very helpful
 hints and pointers to the documentation, which I must say are really helpful.
 
-### Cargo is not a formal verification tool
+### Compiler is not a formal verification tool
 
 This is a very common misconception that stemmed from a recent conversation with one of my non-Rust
 engineer colleagues. For him, it was inconceivable that a Rust program would panic because of an
-out-of-bounds runtime memory fail. Unfortunately, the Cargo compiler is not a one cure for all
+out-of-bounds runtime memory fail. Unfortunately, the Rust compiler is not a one cure for all
 diseases, and obviously it is easy to trick into successfully compiling a program that only fails on
 runtime. Take the following example that uses a very common Rust data structure:
 
@@ -62,7 +62,7 @@ v.clear();
 let _ = v[0]; // panics 
 ```
 
-Or event trickier:
+Or even trickier:
 
 ```rust
 let mut v = Vec::new();
@@ -86,7 +86,7 @@ This came as a surprise to me because it makes dealing with dependencies somewha
 Eventhough most crates are nowadays open source, one can reasonably not audit all their source
 code to assess the "risk" of using them. The poor documentation of most crates also supports this point.
 Having a cargo tree-like tool that analyzes a project's
-dependencies and gives a bird's-eye vue of the crates that are panic-prone would be very helpful.
+dependencies and gives a bird's-eye view of the crates that are panic-prone would be very helpful.
 
 A quick idiomatic alternative to dealing with this problem could be overriding Rust's
 `panic_handler` but unfortunately this is only possible in `#![no_std]` projects.


### PR DESCRIPTION
Cargo isn't a compiler, but a package/build manager. Rust's compiler is called rustc.